### PR TITLE
Jest postgres fix

### DIFF
--- a/ormconfig.js
+++ b/ormconfig.js
@@ -1,4 +1,17 @@
 module.exports = {
+    "type": "postgres",
+    "url": process.env.DATABASE_URL,
+
+    "ssl": process.env.NODE_ENV === 'production'
+        && process.env.DATABASE_URL !== process.env.LOCALHOST
+        && process.env.DATABASE_URL !== process.env.DB ? { rejectUnauthorized: false } : false,
+
+    "entities": ["src/entities/*.ts"],
+    "migrations": ["src/database/migrations/*.ts"],
+
+    "dropSchema": process.env.NODE_ENV === 'test' ? true : false,
+    "migrationsRun": process.env.NODE_ENV !== 'production' ? true : false,
+    
     "cli": {
         "migrationsDir": "src/database/migrations", // typeorm creates migrations in this directory
         "entitiesDir": "src/entities" // typeorm creates entities in this directory

--- a/src/configs/databaseConfigs.ts
+++ b/src/configs/databaseConfigs.ts
@@ -1,16 +1,22 @@
-import { ConnectionOptions } from "typeorm";
-import AllMigrations from "../database/migrations";
-import AllEntities from "../entities";
+import { ConnectionOptions, getConnectionOptions, createConnection } from "typeorm";
+import { CreateUsers1623957922252 } from "../database/migrations/1626667841903-CreateUsers";
+import User from "../entities/User";
 
-export const databaseConfigs = {
-    type: "postgres",
-    ssl: process.env.NODE_ENV === 'production'
-        && process.env.DATABASE_URL !== 'postgres://postgres:docker@localhost:5432/gittin'
-        && process.env.DATABASE_URL !== 'postgres://postgres:docker@db:5432/gittin' ? { rejectUnauthorized: false } : false,
-    url: process.env.DATABASE_URL,
-    entities: AllEntities,
-    migrations: AllMigrations,
-    dropSchema: process.env.NODE_ENV === 'test' ? false : false,
-    migrationsRun: process.env.NODE_ENV !== 'production' ? true : false
+let ormconfig: ConnectionOptions;
 
-} as ConnectionOptions;
+(async () => {
+    ormconfig = await getConnectionOptions();
+    
+    Object.assign(ormconfig, {
+        entities: [
+            User
+        ],
+        migrations: [
+            CreateUsers1623957922252
+        ]
+    });
+})();
+
+export {
+    ormconfig
+};

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,7 +1,7 @@
 import { createConnection } from "typeorm";
-import { databaseConfigs } from "../configs/databaseConfigs";
+import { ormconfig } from "../configs/databaseConfigs";
 
-const connection = createConnection(databaseConfigs);
+const connection = createConnection(ormconfig);
 
 export {
     connection

--- a/src/database/migrations/index.ts
+++ b/src/database/migrations/index.ts
@@ -1,5 +1,0 @@
-import { CreateUsers1623957922252 } from "./1626667841903-CreateUsers";
-
-export default [
-    CreateUsers1623957922252
-];

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -1,5 +1,0 @@
-import User from './User';
-
-export default [
-    User
-];

--- a/src/routes/CreateUser.test.ts
+++ b/src/routes/CreateUser.test.ts
@@ -14,12 +14,15 @@ afterAll(async () => {
 
 describe('POST /api/user', () => {
     it('should return 200', async () => {
-        const response = await st(app).post('/api/users').send({
-            "name": "123",
+        const data = {
+            "name": "joao",
             "password": "123",
-            "email": "docker@123.com",
+            "email": "joao@123.com",
             "admin": true
-        });
-        expect(response.body).toContain('"admin": true');
+        };
+
+        const response = await st(app).post('/api/users').send(data);        
+
+        expect(response.body).toHaveProperty('created_at');
     });
 })


### PR DESCRIPTION
now the way `ormconfig.js` if configured works with either development/production mode and test environment.

When the app is run, the ormconfig information is changed, telling typeorm what entities and migrations it needs to load.

I had to keep all those information in the ormconfig.js because the cli needs it.


the method `.toContain` from jest is not meant for what I needed, so I changed it to `.toHaveProperty`.